### PR TITLE
Revise 3dpreview

### DIFF
--- a/levels/templates/levels/level.html
+++ b/levels/templates/levels/level.html
@@ -5,11 +5,6 @@
 {% block content %}
     <h1>{% block title %}{{ level.name|safe }}{% endblock %}</h1>
 
-    <!-- This is here so 3dpreview can download the level without incrementing
-         the counter.  It caches levels anyway so it was only 1 download per
-         level, but make it easy anyway. -->
-    <!-- DIRECT DOWNLOAD: {{ level.pk }} {{ level.file.url }} -->
-
     {% include "levels/level_crumb.html" %}
 
     <div class="level-info-top-container">

--- a/levels/templates/levels/level.html
+++ b/levels/templates/levels/level.html
@@ -103,8 +103,8 @@
             <div class="level-3d-preview">
                 <h2>3D Preview</h2>
 
-                <p><a href="https://3dpreview.massassi.net/level/{{ level.pk }}/?ownsgame=1">Full Size 3D Preview for {{ level.name|safe }}</a></p>
-                <iframe src="https://3dpreview.massassi.net/level/{{ level.pk }}/?ownsgame=1" width="640" height="480" scrolling="no"></iframe>
+                <p><a href="{{ settings.THREE_DEE_PREVIEW_URL }}/level/?ownsgame=1&amp;url={{ settings.SITE_URL }}{{ level.file.url|urlencode }}">Full Size 3D Preview for {{ level.name|safe }}</a></p>
+                <iframe src="{{ settings.THREE_DEE_PREVIEW_URL }}/level/?ownsgame=1&amp;url={{ settings.SITE_URL }}{{ level.file.url|urlencode }}" width="640" height="480" scrolling="no"></iframe>
             </div>
         {% endif %}
     </div>

--- a/massassi/settings/base.py
+++ b/massassi/settings/base.py
@@ -63,6 +63,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'django_settings_export.settings_export',
             ],
         },
     },
@@ -160,3 +161,9 @@ EMAIL_HOST_USER = 'apikey'
 EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
+
+# Anything in here will be available to TEMPLATES so be careful
+SETTINGS_EXPORT = [
+    'SITE_URL',
+    'THREE_DEE_PREVIEW_URL',
+]

--- a/massassi/settings/dev.py
+++ b/massassi/settings/dev.py
@@ -10,6 +10,9 @@ ALLOWED_HOSTS = ['www.massassi.org']
 
 CSRF_TRUSTED_ORIGINS=['https://www.massassi.org']
 
+SITE_URL = "https://www.massassi.org"
+THREE_DEE_PREVIEW_URL = "https://3dpreview.massassi.org"
+
 # SECURITY WARNING: don't allow this many fields in production
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 5000
 

--- a/massassi/settings/local.py
+++ b/massassi/settings/local.py
@@ -10,6 +10,9 @@ ALLOWED_HOSTS = ['*']
 
 CSRF_TRUSTED_ORIGINS=['*']
 
+SITE_URL = "http://localhost"
+THREE_DEE_PREVIEW_URL = "https://3dpreview.massassi.org"
+
 # SECURITY WARNING: don't allow this many fields in production
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 5000
 

--- a/massassi/settings/prod.py
+++ b/massassi/settings/prod.py
@@ -6,6 +6,9 @@ ALLOWED_HOSTS = ['www.massassi.net', 'massassi.net']
 
 CSRF_TRUSTED_ORIGINS=['https://www.massassi.net']
 
+SITE_URL = "https://www.massassi.net"
+THREE_DEE_PREVIEW_URL = "https://3dpreview.massassi.net"
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Django==4.0.4
 django-appconf==1.0.4
 django-imagekit==4.1.0
 django-s3-storage==0.13.5
+django-settings-export==1.2.1
 gunicorn==20.1.0
 html5lib==1.0.1
 idna==2.8


### PR DESCRIPTION
3d Preview / jkview has been updated to not rely directly on massassi URLs.  Instead the full level download url is provided as an argument and can come from any source.  This updates massassi to use the new 3dpreview url format.