### PR TITLE
fix password reset fail

### DIFF
--- a/holiday/admin.py
+++ b/holiday/admin.py
@@ -30,10 +30,17 @@ class HolidayLogoAdmin(MassassiModelAdmin):
         # If it's an existing logo but the is_in_rotation field changed from False to True, post news.
         should_post_news = change == False or ('is_in_rotation' in form.changed_data and obj.is_in_rotation==True)
 
-        year = datetime.date.today().year
+        today = datetime.date.today()
+        year = today.year
+        month = today.month
 
         # If the logo is for a non-current year, do not post news
-        should_post_news = False if obj.year != year else True
+        if obj.year != year:
+            should_post_news = False
+
+        # Only post news in November & December
+        if month < 11:
+            should_post_news = False
 
         if should_post_news:
             headline_fmt = "New Holiday Logo by {}!"

--- a/holiday/admin.py
+++ b/holiday/admin.py
@@ -31,15 +31,15 @@ class HolidayLogoAdmin(MassassiModelAdmin):
         should_post_news = change == False or ('is_in_rotation' in form.changed_data and obj.is_in_rotation==True)
 
         today = datetime.date.today()
-        year = today.year
-        month = today.month
+        current_year = today.year
+        current_month = today.month
 
         # If the logo is for a non-current year, do not post news
-        if obj.year != year:
+        if obj.year != current_year:
             should_post_news = False
 
         # Only post news in November & December
-        if month < 11:
+        if current_month < 11:
             should_post_news = False
 
         if should_post_news:

--- a/massassi/settings/base.py
+++ b/massassi/settings/base.py
@@ -157,7 +157,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 SENDGRID_API_KEY = get_env_variable('SENDGRID_API_KEY')
 
-DEFAULT_FROM_EMAIL = 'The Massassi Temple <massassi.temple@gmail.com>'
+DEFAULT_FROM_EMAIL = 'The Massassi Temple <noreply@massassi.net>'
 EMAIL_HOST = 'smtp.sendgrid.net'
 EMAIL_HOST_USER = 'apikey'
 EMAIL_HOST_PASSWORD = SENDGRID_API_KEY

--- a/users/templates/users/password_reset_email.html
+++ b/users/templates/users/password_reset_email.html
@@ -1,12 +1,14 @@
 {% autoescape off %}
-    You're receiving this email because you requested a password reset for your user account at massassi.net.
+You're receiving this email because you requested a password reset for your user account at massassi.net.
 
-    Please go to the following page and choose a new password:
-    {% block reset_link %}
-        {{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
-    {% endblock %}
-    Your username, in case you’ve forgotten: {{ user.get_username }}
+Please go to the following page and choose a new password:
+{% block reset_link %}
+{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
+{% endblock %}
+Your username, in case you've forgotten: {{ user.get_username }}
 
-    The Massassi Temple
-    https://www.massassi.net/
+If you are having trouble and need help, please email me: massassi.temple@gmail.com
+
+The Massassi Temple
+https://www.massassi.net/
 {% endautoescape %}


### PR DESCRIPTION
outgoing emails were generating errors because sendgrid changed their outgoing email requirements (fixed by using a FROM address on our domain, instead of gmail)

update password reset email template

minor tweaks to holiday logo news posts